### PR TITLE
fixed ClientConfigException use statement

### DIFF
--- a/src/CodesWholesale/CodesWholesaleClientConfig.php
+++ b/src/CodesWholesale/CodesWholesaleClientConfig.php
@@ -19,7 +19,7 @@ namespace CodesWholesale;
 
 use \fkooman\OAuth\Client\ClientConfig;
 use \fkooman\OAuth\Client\ClientConfigInterface;
-use \fkooman\OAuth\Client\ClientConfigException;
+use \fkooman\OAuth\Client\Exception\ClientConfigException;
 use fkooman\OAuth\Client\StorageInterface;
 
 class CodesWholesaleClientConfig extends ClientConfig implements ClientConfigInterface


### PR DESCRIPTION
On a fresh install, throwing exception from your class crash the app, because ClientConfingException wasn't found.

This PR solve this issue